### PR TITLE
fix: Enhance platform check for stackql installation(macOS)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,166 +1,173 @@
 # Changelog
 
+## v3.6.5 (2024-09-19)
+
+### Bug Fixes
+
+- Fix(MacOS): Enhanced platform check for stackql installation
+- Fix(Test Code): Removed loading of `test.env` in test execution script and Add mocking logic for `pystackql.StackQL`'s methods.
+
 ## v3.6.4 (2024-07-17)
 
 ### Updates
 
- * added dataflow dependency arguments
+- added dataflow dependency arguments
 
 ## v3.6.3 (2024-06-22)
 
 ### Updates
 
- * build updates
+- build updates
 
 ## v3.6.2 (2024-05-06)
 
 ### Updates
 
- * added `rowsaffected` to dict response for `executeStmt`
+- added `rowsaffected` to dict response for `executeStmt`
 
 ## v3.6.1 (2024-04-18)
 
 ### Updates
 
- * modified dict response for `executeStmt`
- * modified error response for `execute`, should never return `None`
+- modified dict response for `executeStmt`
+- modified error response for `execute`, should never return `None`
 
 ## v3.5.4 (2024-04-11)
 
 ### Updates
 
- * added `suppress_errors` argument to the `execute` function
+- added `suppress_errors` argument to the `execute` function
 
 ## v3.5.3 (2024-04-08)
 
 ### Updates
 
- * added `backend_storage_mode` and `backend_file_storage_location` constructor args for specifying a file based backend (not applicable in `server_mode`)
+- added `backend_storage_mode` and `backend_file_storage_location` constructor args for specifying a file based backend (not applicable in `server_mode`)
 
 ## v3.5.2 (2024-03-21)
 
 ### Updates
 
- * added `custom_registry` constructor arg for specifying a non-default registry
+- added `custom_registry` constructor arg for specifying a non-default registry
 
 ## v3.5.1 (2024-03-15)
 
 ### Updates
 
- * included `pandas` and `IPython` install requirements
- * optional required import of `psycopg2` only if in `server_mode`
+- included `pandas` and `IPython` install requirements
+- optional required import of `psycopg2` only if in `server_mode`
 
 ## v3.2.5 (2023-12-07)
 
 ### Updates
 
- * included `app_root` and `execution_concurrency_limit` options in `StackQL` constructor
+- included `app_root` and `execution_concurrency_limit` options in `StackQL` constructor
 
 ## v3.2.4 (2023-10-24)
 
 ### Updates
 
- * implemented non `server_mode` magic extension
- * updated dataframe output for statements
- * `pandas` type updates
- * updated class parameters
- * added additional tests
- * bin path defaults for codespaces notebooks
+- implemented non `server_mode` magic extension
+- updated dataframe output for statements
+- `pandas` type updates
+- updated class parameters
+- added additional tests
+- bin path defaults for codespaces notebooks
 
 ## v3.0.0 (2023-10-11)
 
 ### Updates
 
- * added `StackqlMagic` class for `jupyter`, `IPython` integration
- * `server_mode` is now used to connect to a `stackql` server process using `pyscopg2`
- * added additional tests
+- added `StackqlMagic` class for `jupyter`, `IPython` integration
+- `server_mode` is now used to connect to a `stackql` server process using `pyscopg2`
+- added additional tests
 
 ## v2.0.0 (2023-08-15)
 
 ### Updates
 
- * added `executeQueriesAsync` stackql class method
+- added `executeQueriesAsync` stackql class method
 
 ## v1.5.0 (2023-04-04)
 
 ### Updates
 
- * added `server_mode` to run a background stackql server process
+- added `server_mode` to run a background stackql server process
 
 ## v1.0.2 (2023-02-23)
 
 ### Updates
 
- * enabled custom `download_dir` argument
+- enabled custom `download_dir` argument
 
 ## v1.0.1 (2023-02-23)
 
 ### Minor updates
 
- * updated `setup.py`
+- updated `setup.py`
 
 ## v1.0.0 (2023-02-22)
 
 ### Refactor
 
- * refactored package
- * added support for `kwargs` for the `StackQL` constructor
- * added `setup.py`
- * added `docs` using `sphinx`
- * added additional tests
+- refactored package
+- added support for `kwargs` for the `StackQL` constructor
+- added `setup.py`
+- added `docs` using `sphinx`
+- added additional tests
 
 ## v0.9.0 (2022-06-06)
 
 ### Bug Fixes
 
- * added exception handling
+- added exception handling
 
 ## v0.5.0 (2022-06-03)
 
 ### Bug Fixes
 
- * added local registry support
- * updated docs
+- added local registry support
+- updated docs
 
 ## v0.4.1 (2022-05-31)
 
 ### Bug Fixes
 
- * added `str` handling
- * updated docs
+- added `str` handling
+- updated docs
 
 ## v0.4.0 (2022-02-08)
 
 ### Updates
 
- * updated `version` output
- * updated docs
+- updated `version` output
+- updated docs
 
 ## v0.3.0 (2022-02-07)
 
 ### Initial release as `pystackql`
 
- * added `auth` switch
- * converted `byte` output to `str`
+- added `auth` switch
+- converted `byte` output to `str`
 
 ## v0.2.0 (2021-07-19)
 
 ### Updates to `pyinfraql`
 
- * added `version` method
- * updates to accept `None` for arguments
- * updated docs
+- added `version` method
+- updates to accept `None` for arguments
+- updated docs
 
 ## v0.1.1 (2021-07-16)
 
 ### Updates to `pyinfraql`
 
- * added `dbfilepath` argument
+- added `dbfilepath` argument
 
 ## v0.1.0 (2021-02-15)
 
 ### Initial Release (as `pyinfraql`)
 
- * class constructor for `pyinfraql`
- * support for `google` provider
- * support for integration with `pandas`, `matplotlib` and `jupyter`
+- class constructor for `pyinfraql`
+- support for `google` provider
+- support for integration with `pandas`, `matplotlib` and `jupyter`

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -26,7 +26,7 @@ author = 'StackQL Studios'
 # The short X.Y version
 version = ''
 # The full version, including alpha/beta/rc tags
-release = '3.6.4'
+release = 'v3.6.5'
 
 
 # -- General configuration ---------------------------------------------------

--- a/pystackql/_util.py
+++ b/pystackql/_util.py
@@ -80,25 +80,28 @@ def _download_file(url, path, showprogress=True):
 		exit(1)
 
 def _setup(download_dir, platform, showprogress=False):
-	print('installing stackql...')
-	try:
-		binary_name = _get_binary_name(platform)
-		url = _get_url()
-		print("downloading latest version of stackql from %s to %s" % (url, download_dir))
-		archive_file_name = os.path.join(download_dir, os.path.basename(url))
-		_download_file(url, archive_file_name, showprogress)
-		if platform == 'Darwin':
-			unpacked_file_name = os.path.join(download_dir, 'stackql')
-			command = 'pkgutil --expand-full {} {}'.format(archive_file_name, unpacked_file_name)
-			os.system(command)
-		else:
-			with zipfile.ZipFile(archive_file_name, 'r') as zip_ref:
-				zip_ref.extractall(download_dir) 
-
-		os.chmod(os.path.join(download_dir, binary_name), 0o755)
-	except Exception as e:
-		print("ERROR: [_setup] %s" % (str(e)))
-		exit(1)
+    try:
+        print('installing stackql...')
+        binary_name = _get_binary_name(platform)
+        url = _get_url()
+        print("downloading latest version of stackql from %s to %s" % (url, download_dir))
+        archive_file_name = os.path.join(download_dir, os.path.basename(url))
+        _download_file(url, archive_file_name, showprogress)
+        # if Platform is starting with Darwin, then it is a MacOS
+        if platform.startswith('Darwin'):
+            unpacked_file_name = os.path.join(download_dir, 'stackql')
+            command = 'pkgutil --expand-full {} {}'.format(archive_file_name, unpacked_file_name)
+            # if there are files in unpacked_file_name, then remove them
+            if os.path.exists(unpacked_file_name):
+                os.system('rm -rf {}'.format(unpacked_file_name))
+            os.system(command)
+        else:
+            with zipfile.ZipFile(archive_file_name, 'r') as zip_ref:
+                zip_ref.extractall(download_dir) 
+        os.chmod(os.path.join(download_dir, binary_name), 0o755)
+    except Exception as e:
+        print("ERROR: [_setup] %s" % (str(e)))
+        exit(1)
 
 def _get_version(bin_path):
     try:

--- a/run_tests
+++ b/run_tests
@@ -1,3 +1,2 @@
 #!/bin/bash
-. tests/creds/env_vars/test.env
 python3 -m tests.pystackql_tests

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open('LICENSE') as f:
 
 setup(
     name='pystackql',
-    version='3.6.4',
+    version='v3.6.5',
     description='A Python interface for StackQL',
     long_description=readme,
     author='Jeffrey Aven',

--- a/tests/test_params.py
+++ b/tests/test_params.py
@@ -1,4 +1,4 @@
-import json, os, sys, platform, re, time, unittest, subprocess
+import json, sys, platform, re, time, unittest, subprocess
 import pandas as pd
 from termcolor import colored
 import unittest.mock as mock
@@ -33,11 +33,14 @@ registry_pull_github_query = "REGISTRY PULL github"
 def registry_pull_resp_pattern(provider):
     return r"%s provider, version 'v\d+\.\d+\.\d+' successfully installed\s*" % provider
 
+test_gcp_project_id = "test-gcp-project"
+test_gcp_zone = "australia-southeast2-a"
+
 google_query = f"""
 SELECT status, count(*) as num_instances
 FROM google.compute.instances
-WHERE project = '{os.environ['GCP_PROJECT']}' 
-AND zone = '{os.environ['GCP_ZONE']}'
+WHERE project = '{test_gcp_project_id}' 
+AND zone = '{test_gcp_zone}'
 GROUP BY status
 """
 
@@ -50,7 +53,7 @@ WHERE region = 'ap-southeast-2'
 GROUP BY instance_type
 """
 
-regions = os.environ.get('AWS_REGIONS').split(',')
+test_aws_regions = ["ap-southeast-2", "ap-southeast-4"]
 
 async_queries = [
     f"""
@@ -58,7 +61,7 @@ async_queries = [
     FROM aws.lambda.functions
     WHERE region = '{region}'
     """
-    for region in regions
+    for region in test_aws_regions
 ]
 
 def print_test_result(test_name, condition=True, server_mode=False, is_ipython=False):


### PR DESCRIPTION
## This PR enhances the reliability of stackql installation on MacOS + Fix Test Codes by:

#### 1) Modifying the platform check to use startswith('Darwin') instead of strict equality. This ensures compatibility with various Darwin-based OS versions.

When `_setup` function check the platform, MacOS user's platform is not excatly `Darwin`,
but it just starts with `Darwin`, so I changed the condition to check if `platform.startswith('Darwin')`.
![image](https://github.com/user-attachments/assets/413e50b2-421e-42f4-839f-e2d07d5cad8c)

#### 2) Adding a step to clear any existing files in the unpacked directory before extracting the new stackql binary. This prevents potential conflicts and ensures a clean installation.

[before]
```python
command = 'pkgutil --expand-full {} {}'.format(archive_file_name, unpacked_file_name)
os.system(command)
```
command is like `pkgutil --expand-full /Users/derek/.local/stackql_darwin_multiarch.pkg /Users/derek/.local/stackql`
- `/Users/derek/.local/stackql_darwin_multiarch.pkg`(archive_file_name): This is the path to your macOS package file.
- `/Users/derek/.local/stackql`(unpacked_file_name): This is the directory where the package's contents will be extracted.
But if I didn't remove `unpacked_file_name`, there was an error like below,

![image](https://github.com/user-attachments/assets/2038d98d-fa82-49fa-9362-6d4f36d23571)

So I add remove existing `unpacked_file_name` to make a new `unpacked_file_name`.
After I apply this logic, there are no error like above.

![image](https://github.com/user-attachments/assets/ff1ea1a3-68e0-4276-b36a-a7d5590d7bf9)
(Sorry for debugging message..!)

But if there are any other options instead of deleting `unpacked_file_name`, let me know any time 😃 


#### 3) Removing External Dependencies: Eliminated the reliance on the test.env file during test execution. This enables me to test locally without `test.env` file

[before]
![image](https://github.com/user-attachments/assets/cc593e98-0716-4d4a-8f01-8ab15a1ed410)

[after]
After I deleted `. tests/creds/env_vars/test.env` execution logic, there is no error.
Instead, I changed `os.environ[VARIABLES]` to simple string value.
![image](https://github.com/user-attachments/assets/1e216ecc-b138-4f29-aae3-761b01a76300)

#### 4) Introducing Mocking for Server Mode Tests: Added mocking logic to simulate the behavior of pystackql.StackQL methods in server mode. 

[before]
There were errors, because it tried to execute real methods such as `pystackql.StackQL.execute`, `pystackql.stackql.StackQL._run_server_query`.
![image](https://github.com/user-attachments/assets/2811a5f1-96b2-474e-9d49-e90b229f32b4)

[After]
After I mock the method and the response, it doesn't make any error.
![image](https://github.com/user-attachments/assets/8ab01771-2196-4df3-a2d7-223ade5acfbd)
